### PR TITLE
Fix crash if machine's config.ini doesn't exist

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -547,6 +547,10 @@ bool retro_load_game(const struct retro_game_info *info)
          boardSetMachine(machine);
          machineDestroy(machine);
       }
+      else
+      {
+         return false;
+      }
    }
    boardSetFdcTimingEnable(properties->emulation.enableFdcTiming);
    boardSetY8950Enable(properties->sound.chip.enableY8950);


### PR DESCRIPTION
Some kodi users and I are having a hard time figuring out how to get BlueMSX working with BIOS files. (know of any guides?) In the meantime, BlueMSX was incorrectly reporting success loading the game, leading to a crash on the first call to `retro_run()`. This fixes the return value when the machine's config.ini doesn't exist. Kodi no longer crashes, and properly reports that the ROM failed to load.