### PR TITLE
Use git version as library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,6 +1,8 @@
 TARGET_NAME := bluemsx
-GIT_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags)"
-CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+GIT_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags || echo unknown)"
+ifneq ($(GIT_VERSION),"unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 DEBUG   = 0
 LOG_PERFORMANCE = 1

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,4 +1,6 @@
 TARGET_NAME := bluemsx
+GIT_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags)"
+CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 
 DEBUG   = 0
 LOG_PERFORMANCE = 1

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,6 +1,6 @@
 TARGET_NAME := bluemsx
-GIT_VERSION := "$(shell git describe --abbrev=7 --dirty --always --tags || echo unknown)"
-ifneq ($(GIT_VERSION),"unknown")
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,4 +1,8 @@
 LOCAL_PATH := $(call my-dir)
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
 include $(CLEAR_VARS)
 

--- a/libretro.c
+++ b/libretro.c
@@ -231,7 +231,7 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "blueMSX";
 #ifdef GIT_VERSION
-   info->library_version = GIT_VERSION;
+   info->library_version = "git" GIT_VERSION;
 #else
    info->library_version = "svn";
 #endif

--- a/libretro.c
+++ b/libretro.c
@@ -230,7 +230,11 @@ static int double_width;
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "blueMSX";
+#ifdef GIT_VERSION
+   info->library_version = GIT_VERSION;
+#else
    info->library_version = "svn";
+#endif
    info->need_fullpath = true;
    info->block_extract = false;
    info->valid_extensions = "rom|ri|mx1|mx2|col|sg|sc";


### PR DESCRIPTION
This patch makes this core report the git version as its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.