### PR TITLE
Fix system ROM loading on 64-bit Linux

### DIFF
--- a/Src/Board/Machine.c
+++ b/Src/Board/Machine.c
@@ -25,7 +25,7 @@
 **
 ******************************************************************************
 */
-#ifdef EMSCRIPTEN
+#if defined(__linux__) || defined(EMSCRIPTEN)
 #define _GNU_SOURCE
 #endif
 #include <string.h>


### PR DESCRIPTION
Glibc does not declare strcasestr() unless _GNU_SOURCE is defined. As a result, strcasestr() returns an incorrect pointer value on 64-bit Linux and the core fails to read system ROMs.