### PR TITLE
Add m3u playlist support for disk swapping.

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -729,7 +729,8 @@ static void check_variables(void)
    {
       if (!strcmp(var.value, "Auto"))
          mapper_auto = true;
-      else {
+      else 
+      {
          mapper_auto = false;
          strcpy(msx_cartmapper, var.value);
       }

--- a/libretro.c
+++ b/libretro.c
@@ -81,6 +81,11 @@ static struct retro_perf_callback perf_cb;
 #define RETRO_DEVICE_MAPPER RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 1)
 #define EC_KEYBOARD_KEYCOUNT  94
 
+#ifdef _WIN32
+#define SLASH '\\'
+#else
+#define SLASH '/'
+#endif
 
 /* .dsk support */
 enum{
@@ -739,11 +744,6 @@ bool retro_load_game(const struct retro_game_info *info)
    char properties_dir[256], machines_dir[256], mediadb_dir[256];
    const char *dir = NULL;
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_RGB565;
-#ifdef _WIN32
-   char slash = '\\';
-#else
-   char slash = '/';
-#endif
 
    if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
    {
@@ -771,8 +771,8 @@ bool retro_load_game(const struct retro_game_info *info)
    else /* Fallback */
       extract_directory(properties_dir, info->path, sizeof(properties_dir));
 
-   snprintf(machines_dir, sizeof(machines_dir), "%s%c%s", properties_dir, slash, "Machines");
-   snprintf(mediadb_dir, sizeof(mediadb_dir), "%s%c%s", properties_dir, slash, "Databases");
+   snprintf(machines_dir, sizeof(machines_dir), "%s%c%s", properties_dir, SLASH, "Machines");
+   snprintf(mediadb_dir, sizeof(mediadb_dir), "%s%c%s", properties_dir, SLASH, "Databases");
 
    propertiesSetDirectory(properties_dir, properties_dir);
    machineSetDirectory(machines_dir);

--- a/libretro.c
+++ b/libretro.c
@@ -87,6 +87,10 @@ static struct retro_perf_callback perf_cb;
 #define SLASH '/'
 #endif
 
+#ifndef PATH_MAX
+#define PATH_MAX  4096
+#endif
+
 /* .dsk support */
 enum{
    MEDIA_TYPE_CART = 0,
@@ -106,7 +110,7 @@ void lower_string(char* str)
 
 int get_media_type(const char* filename)
 {
-   char workram[4096/*max path name length for all existing OSes*/];
+   char workram[PATH_MAX];
    const char *extension = NULL;
 
    strcpy(workram, filename);
@@ -166,7 +170,7 @@ int get_media_type(const char* filename)
 struct retro_disk_control_callback dskcb;
 unsigned disk_index = 0;
 unsigned disk_images = 1;
-char disk_paths[10][4096/*max path name length for all existing OSes*/];
+char disk_paths[10][PATH_MAX];
 bool disk_inserted = true;//default is true the first disk is the one that loads the core
 
 bool set_eject_state(bool ejected)

--- a/libretro.c
+++ b/libretro.c
@@ -578,7 +578,7 @@ void retro_set_controller_port_device(unsigned port, unsigned device)
             break;
          default:
             if (log_cb)
-               log_cb(RETRO_LOG_ERROR, "[libretro]: Invalid device, setting type to RETRO_DEVICE_JOYPAD ...\n");
+               log_cb(RETRO_LOG_ERROR, "%s\n", "[libretro]: Invalid device, setting type to RETRO_DEVICE_JOYPAD ...");
             input_devices[port] = RETRO_DEVICE_JOYPAD;
       }
    }
@@ -752,7 +752,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (!environ_cb(RETRO_ENVIRONMENT_SET_PIXEL_FORMAT, &fmt))
    {
       if (log_cb)
-         log_cb(RETRO_LOG_INFO, "RGB565 is not supported.\n");
+         log_cb(RETRO_LOG_INFO, "%s\n", "RGB565 is not supported.");
       return false;
    }
 


### PR DESCRIPTION
The main purpose of this PR is to add m3u support so disk swapping can be done without needing to use the RGUI file browser to select the next disk image. Have compiled & tested this on Windows 10 x64 and also RPI3 running Jessie.

Any feedback is welcome.