### PR TITLE
Add the first 2 disks from an m3u playlist to the properties object, …

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -928,7 +928,10 @@ bool retro_load_game(const struct retro_game_info *info)
                log_cb(RETRO_LOG_ERROR, "%s\n", "[libretro]: failed to read m3u file ...");
             return false;
          }
-         strcpy(properties->media.disks[0].fileName , disk_paths[0]);
+         for (i = 0; (i <= disk_images) && (i <= 1); i++)
+         {
+            strcpy(properties->media.disks[i].fileName , disk_paths[i]);
+         }
          disk_inserted = true;
          attach_disk_swap_interface();
          break;


### PR DESCRIPTION
…to support games where it requires disks in both Drive A and Drive B simultaneously. (i.e. Xanadu).

Tested with about 30 different multi-disk games and I did not notice any negative impact of loading 2 disks, and this allowed Xanadu to work properly.