### PR TITLE
Fix memory hooks for ColecoVision

### DIFF
--- a/Src/Board/Machine.c
+++ b/Src/Board/Machine.c
@@ -1823,16 +1823,19 @@ int machineInitialize(Machine* machine, UInt8** mainRam, UInt32* mainRamSize, UI
 
     if (mainRam != NULL) {
         *mainRam = ram;
-	g_mainRam = ram ;
     }
     
     if (mainRamSize != NULL) {
         *mainRamSize = ramSize;
-	g_mainRamSize = ramSize ;
     }
 
     if (mainRamStart != NULL) {
         *mainRamStart = ramStart;
+    }
+
+    if (ramSize != 0) {
+        g_mainRamSize = ramSize;
+        g_mainRam = ram;
     }
 
     return success;


### PR DESCRIPTION
ColecoVision passes null/0 to this function and has it take care of memory initialization itself. This change checks the initialized memory instead of the arguments passed to the function, so cheats and achievements can work