### PR TITLE
Fix build with clang using static casts.

### DIFF
--- a/Src/SoundChips/OpenMsxYM2413_2.cpp
+++ b/Src/SoundChips/OpenMsxYM2413_2.cpp
@@ -783,10 +783,22 @@ void OpenYM2413_2::Slot::calc_envelope(int lfo_am)
 {
 	#define S2E(x) (SL2EG((int)(x / SL_STEP)) << (EG_DP_BITS - EG_BITS)) 
 	static unsigned int SL[16] = {
-		S2E( 0.0), S2E( 3.0), S2E( 6.0), S2E( 9.0),
-		S2E(12.0), S2E(15.0), S2E(18.0), S2E(21.0),
-		S2E(24.0), S2E(27.0), S2E(30.0), S2E(33.0),
-		S2E(36.0), S2E(39.0), S2E(42.0), S2E(48.0)
+		static_cast<unsigned int>(S2E( 0.0)),
+		static_cast<unsigned int>(S2E( 3.0)),
+		static_cast<unsigned int>(S2E( 6.0)),
+		static_cast<unsigned int>(S2E( 9.0)),
+		static_cast<unsigned int>(S2E(12.0)),
+		static_cast<unsigned int>(S2E(15.0)),
+		static_cast<unsigned int>(S2E(18.0)),
+		static_cast<unsigned int>(S2E(21.0)),
+		static_cast<unsigned int>(S2E(24.0)),
+		static_cast<unsigned int>(S2E(27.0)),
+		static_cast<unsigned int>(S2E(30.0)),
+		static_cast<unsigned int>(S2E(33.0)),
+		static_cast<unsigned int>(S2E(36.0)),
+		static_cast<unsigned int>(S2E(39.0)),
+		static_cast<unsigned int>(S2E(42.0)),
+		static_cast<unsigned int>(S2E(48.0))
 	};
 
 	unsigned out;

--- a/Src/SoundChips/OpenMsxYMF278.cpp
+++ b/Src/SoundChips/OpenMsxYMF278.cpp
@@ -145,8 +145,10 @@ const int vib_depth[8] = {
 
 #define SC(db) (unsigned int) (db * (2.0 / ENV_STEP))
 const int am_depth[8] = {
-	SC(0),	   SC(1.781), SC(2.906), SC(3.656),
-	SC(4.406), SC(5.906), SC(7.406), SC(11.91)
+	static_cast<int>(SC(0)), static_cast<int>(SC(1.781)),
+	static_cast<int>(SC(2.906)), static_cast<int>(SC(3.656)),
+	static_cast<int>(SC(4.406)), static_cast<int>(SC(5.906)),
+	static_cast<int>(SC(7.406)), static_cast<int>(SC(11.91))
 };
 #undef SC
 


### PR DESCRIPTION
Fixes several build errors with `clang-8.0.0` using static casts as suggested by the compiler.
```
Src/SoundChips/OpenMsxYM2413_2.cpp:786:3: error: non-constant-expression cannot be narrowed from type 'int' to 'unsigned int' in initializer list [-Wc++11-narrowing]
                S2E( 0.0), S2E( 3.0), S2E( 6.0), S2E( 9.0),
                ^~~~~~~~~
Src/SoundChips/OpenMsxYM2413_2.cpp:784:17: note: expanded from macro 'S2E'
        #define S2E(x) (SL2EG((int)(x / SL_STEP)) << (EG_DP_BITS - EG_BITS)) 
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Src/SoundChips/OpenMsxYM2413_2.cpp:786:3: note: insert an explicit cast to silence this issue
                S2E( 0.0), S2E( 3.0), S2E( 6.0), S2E( 9.0),
                ^~~~~~~~~
                static_cast<unsigned int>( )
Src/SoundChips/OpenMsxYM2413_2.cpp:784:17: note: expanded from macro 'S2E'
        #define S2E(x) (SL2EG((int)(x / SL_STEP)) << (EG_DP_BITS - EG_BITS)) 
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
````

Reference: https://stackoverflow.com/questions/46545847/is-it-possible-to-avoid-static-cast-in-initializer-list