### PR TITLE
Fix build under clang

### DIFF
--- a/Src/SoundChips/OpenMsxYM2413_2.cpp
+++ b/Src/SoundChips/OpenMsxYM2413_2.cpp
@@ -781,7 +781,7 @@ inline void OpenYM2413_2::update_noise()
 // EG
 void OpenYM2413_2::Slot::calc_envelope(int lfo_am)
 {
-	#define S2E(x) (SL2EG((int)(x / SL_STEP)) << (EG_DP_BITS - EG_BITS)) 
+	#define S2E(x) static_cast<unsigned int>(SL2EG((int)(x / SL_STEP)) << (EG_DP_BITS - EG_BITS))
 	static unsigned int SL[16] = {
 		S2E( 0.0), S2E( 3.0), S2E( 6.0), S2E( 9.0),
 		S2E(12.0), S2E(15.0), S2E(18.0), S2E(21.0),

--- a/Src/SoundChips/OpenMsxYMF278.cpp
+++ b/Src/SoundChips/OpenMsxYMF278.cpp
@@ -143,7 +143,7 @@ const int vib_depth[8] = {
 #undef O
 
 
-#define SC(db) (unsigned int) (db * (2.0 / ENV_STEP))
+#define SC(db) static_cast<int>(db * (2.0 / ENV_STEP))
 const int am_depth[8] = {
 	SC(0),	   SC(1.781), SC(2.906), SC(3.656),
 	SC(4.406), SC(5.906), SC(7.406), SC(11.91)


### PR DESCRIPTION
Clang seems to be less permissive because it trigger errors regarding conversion in initializers list.

```
Src/SoundChips/OpenMsxYM2413_2.cpp:788:14: error: non-constant-expression cannot be narrowed from type 'int' to 'unsigned int' in initializer list [-Wc++11-narrowing]
                S2E(24.0), S2E(27.0), S2E(30.0), S2E(33.0),
                           ^~~~~~~~~
```