### PR TITLE
Explicitly set C and C++ standard versions

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,4 +1,6 @@
 TARGET_NAME := bluemsx
+CFLAGS := -std=gnu89
+CXXFLAGS := -std=gnu++98
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")
 	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"


### PR DESCRIPTION
Them being unset leads to newer compilers assuming newer standards than the code actually is. This has the unfortunate side effect that some diagnostics that have been warnings (and ignored thanks to -w) are now promoted to errors, which prevents successful compilation.

A bad decision had been taken to directly operate on CFLAGS and CXXFLAGS within the makefiles. This breaks the expectation that one can set custom CFLAGS and CXXFLAGS as a paramter to make invocation and see the libretro core compiled with the requested flags together with the ones needed (including the prominent -fPIC and -D__LIBRETRO__ parameters). I'm not fixing that here.

Arguably, the fix here is to replace all the types from pointer to a specific RomMapper to pointer to void, and cast that to the specific RomMapper within the function's body, but there are hundreds of instances of this problem, so I'm not doing this here either.

Admittedly, my choice as to the version standards is arbitrary and I'm not particularly attached to it. Anything that works for me would be great to have.