### PR TITLE
Fix incorrect NULL usage

### DIFF
--- a/Src/Utils/IniFileParser.c
+++ b/Src/Utils/IniFileParser.c
@@ -207,7 +207,6 @@ IniFile *iniFileOpen(const char *filename)
     if (iniFile != NULL)
     {
         iniFile->isZipped = 0;
-        iniFile->isZipped = NULL;
         
         iniFile->modified = 0;
         


### PR DESCRIPTION
Fixes int-conversion compile issue with gcc-14.1

/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/bin/x86_64-libreelec-linux-gnu-gcc -c -oSrc/Input/SviJoyIo.o Src/Input/SviJoyIo.c -march=x86-64-v3 -Wall -pipe  -Wno-incompatible-pointer-types -O2 -fomit-frame-pointer -DNDEBUG -DGIT_VERSION=\"" 0ce76b4e08"\" -O2 -fPIC  -D__LIBRETRO__ -DSINGLE_THREADED -DVIDEO_COLOR_TYPE_RGB565 -DZ80_CUSTOM_CONFIGURATION -w  -I. -I./libretro-common/include -I./Src/Arch -I./Src/Bios -I./Src/Board -I./Src/BuildInfo -I./Src/Common -I./Src/Debugger -I./Src/Emulator -I./Src/IoDevice -I./Src/Language -I./Src/Media -I./Src/Memory -I./Src/Resources -I./Src/SoundChips -I./Src/TinyXML -I./Src/Unzip -I./Src/Utils -I./Src/VideoChips -I./Src/VideoRender -I./Src/Z80 -I./Src/Input -I./Src/Libretro -I./deps/zlib  Src/Utils/IniFileParser.c: In function 'iniFileOpen': Src/Utils/IniFileParser.c:210:27: error: assignment to 'int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
  210 |         iniFile->isZipped = NULL;
      |                           ^