### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -361,7 +361,7 @@ else ifeq ($(platform), wiiu)
 	CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	PLATFORM_DEFINES += -DGEKKO -DWIIU -DHW_RVL -mcpu=750 -meabi -mhard-float
-	PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+	PLATFORM_DEFINES += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
 	STATIC_LINKING = 1
 	HAVE_COMPAT = 1
 


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)