### PR TITLE
Add "Enable io sound" core option

### DIFF
--- a/Src/Emulator/Properties.c
+++ b/Src/Emulator/Properties.c
@@ -292,8 +292,8 @@ void propInitDefaults(Properties* properties, int langType, PropKeyboardLanguage
     properties->sound.mixerChannel[MIXER_CHANNEL_PCM].pan = 50;
     properties->sound.mixerChannel[MIXER_CHANNEL_PCM].volume = 95;
 
-    properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 1;
-    properties->sound.mixerChannel[MIXER_CHANNEL_IO].pan = 60;
+    properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 0;
+    properties->sound.mixerChannel[MIXER_CHANNEL_IO].pan = 50;
     properties->sound.mixerChannel[MIXER_CHANNEL_IO].volume = 50;
 
     properties->sound.mixerChannel[MIXER_CHANNEL_MIDI].enable = 1;

--- a/Src/Emulator/Properties.c
+++ b/Src/Emulator/Properties.c
@@ -292,8 +292,8 @@ void propInitDefaults(Properties* properties, int langType, PropKeyboardLanguage
     properties->sound.mixerChannel[MIXER_CHANNEL_PCM].pan = 50;
     properties->sound.mixerChannel[MIXER_CHANNEL_PCM].volume = 95;
 
-    properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 0;
-    properties->sound.mixerChannel[MIXER_CHANNEL_IO].pan = 50;
+    properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 1;
+    properties->sound.mixerChannel[MIXER_CHANNEL_IO].pan = 60;
     properties->sound.mixerChannel[MIXER_CHANNEL_IO].volume = 50;
 
     properties->sound.mixerChannel[MIXER_CHANNEL_MIDI].enable = 1;

--- a/libretro.c
+++ b/libretro.c
@@ -822,7 +822,10 @@ static void check_variables(void)
    else
       auto_rewind_cas = true;
 
-   reevaluate_variables_io_sound(true);
+   if (properties != NULL) // Avoid first run (check_variables() is called before propCreate())
+   {
+      reevaluate_variables_io_sound(true);
+   }
 
    if (geometry_update)
    {
@@ -835,24 +838,21 @@ static void reevaluate_variables_io_sound(bool setToMixer)
 {
    struct retro_variable var;
 
-   if (properties != NULL)
+   var.key = "bluemsx_sound_io_enable";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      var.key = "bluemsx_sound_io_enable";
-      var.value = NULL;
-
-      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-      {
-         if (!strcmp(var.value, "disabled"))
-            properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 0;
-         else if (!strcmp(var.value, "enabled"))
-            properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 1;
-      }
-      else
+      if (!strcmp(var.value, "disabled"))
          properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 0;
-
-      if (setToMixer)
-         mixerEnableChannelType(mixer, MIXER_CHANNEL_IO, properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable);
+      else if (!strcmp(var.value, "enabled"))
+         properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 1;
    }
+   else
+      properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable = 0;
+
+   if (setToMixer)
+      mixerEnableChannelType(mixer, MIXER_CHANNEL_IO, properties->sound.mixerChannel[MIXER_CHANNEL_IO].enable);
 }
 
 bool retro_load_game(const struct retro_game_info *info)

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -148,6 +148,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "ON"
    },
+   {
+      "bluemsx_sound_io_enable",
+      "I/O Sound Enable",
+      "Enable the I/O sound (floppy disk access sound).",
+      {
+         { "enabled",   NULL },
+         { "disabled",   NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 


### PR DESCRIPTION
Hello,

I would like to propose the implementation of a core option that enables the I/O sound, as originally implemented in blueMSX. The I/O sound indicates FDD usage and emulates the seek sound of a busy FDD, providing an authentic experience similar to the actual hardware.

This pull request includes the following features:

- Adds an option to the core settings to enable or disable the I/O sound. By default, this option is disabled, ensuring that existing users are not unexpectedly affected by the update.

Please let me know if further information is required according to the repository's community guidelines.

Thank you for considering my contribution.

Best regards,

Tetsuo Honda