### PR TITLE
Fix extension checking and SG-1000 8KB RAM mapper

### DIFF
--- a/Src/Memory/romMapperSg1000RamExpander.c
+++ b/Src/Memory/romMapperSg1000RamExpander.c
@@ -83,9 +83,19 @@ static UInt8 read(RomMapperSg1000RamExpander* rm, UInt16 address)
     return rm->ram2[address & rm->mask2];
 }
 
+static UInt8 read_ram1(RomMapperSg1000RamExpander* rm, UInt16 address) 
+{
+    return rm->ram1[address - 0x2000];
+}
+
 static void write(RomMapperSg1000RamExpander* rm, UInt16 address, UInt8 value) 
 {
     rm->ram2[address & rm->mask2] = value;
+}
+
+static void write_ram1(RomMapperSg1000RamExpander* rm, UInt16 address, UInt8 value) 
+{
+    rm->ram1[address-0x2000] =  value;
 }
 
 int romMapperSg1000RamExpanderCreate(const char* filename, UInt8* romData, 
@@ -96,19 +106,19 @@ int romMapperSg1000RamExpanderCreate(const char* filename, UInt8* romData,
     int pages = size / 0x2000 + ((size & 0x1fff) ? 1 : 0);
     int i;
 
-    if (size != 0x8000 || startPage != 0) {
-        return 0;
-    }
+    // Some ROMs are 48KB
+    // if (size != 0x8000 || startPage != 0) {
+    //     return 0;
+    // }
 
     rm = malloc(sizeof(RomMapperSg1000RamExpander));
 
     rm->deviceHandle = deviceManagerRegister(type, &callbacks, rm);
-    slotRegister(slot, sslot, startPage, pages, read, read, write, destroy, rm);
 
     rm->romData = malloc(pages * 0x2000);
     memcpy(rm->romData, romData, size);
-    memset(rm->ram1, sizeof(rm->ram1), 0xff);
-    memset(rm->ram2, sizeof(rm->ram2), 0xff);
+    memset(rm->ram1, 0xff, sizeof(rm->ram1));
+    memset(rm->ram2, 0xff, sizeof(rm->ram2));
 
     rm->slot  = slot;
     rm->sslot = sslot;
@@ -118,15 +128,15 @@ int romMapperSg1000RamExpanderCreate(const char* filename, UInt8* romData,
     for (i = 0; i < pages; i++) {
         if (i + startPage >= 2) slot = 0;
         if (type == ROM_SG1000_RAMEXPANDER_A && i + startPage == 1) {
-            slotMapPage(slot, sslot, i + startPage, rm->ram1, 1, 1);
+            slotRegister(slot, sslot, i + startPage, 1, read_ram1, read_ram1, write_ram1, destroy, rm);
         }
         else {
             slotMapPage(slot, sslot, i + startPage, rm->romData + 0x2000 * i, 1, 0);
         }
     }
 
-    slotMapPage(slot, sslot, 6, NULL, 0, 0);
-    slotMapPage(slot, sslot, 7, NULL, 0, 0);
+    slotMapPage(0, 0, 6, rm->ram2, 1, 1);
+    slotMapPage(0, 0, 7, rm->ram2, 1, 1);
 
     return 1;
 }

--- a/libretro.c
+++ b/libretro.c
@@ -122,39 +122,39 @@ int get_media_type(const char* filename)
 
    strcpy(workram, filename);
    lower_string(workram);
-   extension = workram + strlen(workram) - 4;
+   extension = workram + strlen(workram) - 3;
 
-   if(strcmp(extension, ".dsk") == 0){
+   if(strcmp(extension, "dsk") == 0){
       if (is_auto)
          strcpy(msx_type, "MSX2+");
       return MEDIA_TYPE_DISK;
    }
-   else if(strcmp(extension, ".m3u") == 0){
+   else if(strcmp(extension, "m3u") == 0){
       if (is_auto)
          strcpy(msx_type, "MSX2+");
       return MEDIA_TYPE_DISK_BUNDLE;
    }
-   else if(strcmp(extension, ".cas") == 0){
+   else if(strcmp(extension, "cas") == 0){
       if (is_auto)
          strcpy(msx_type, "MSX2+");
       return MEDIA_TYPE_TAPE;
    }
-   else if(strcmp(extension, ".rom") == 0){
+   else if(strcmp(extension, "rom") == 0){
       if (is_auto)
          strcpy(msx_type, "MSX2+");
       return MEDIA_TYPE_CART;
    }
-   else if(strcmp(extension, ".mx1") == 0){
+   else if(strcmp(extension, "mx1") == 0){
       if (is_auto)
          strcpy(msx_type, "MSX2+");
       return MEDIA_TYPE_CART;
    }
-   else if(strcmp(extension, ".mx2") == 0){
+   else if(strcmp(extension, "mx2") == 0){
       if (is_auto)
          strcpy(msx_type, "MSX2+");
       return MEDIA_TYPE_CART;
    }
-   else if(strcmp(extension, ".col") == 0){
+   else if(strcmp(extension, "col") == 0){
       if (is_auto){
          is_coleco = true;
          strcpy(msx_type, "COL - ColecoVision");
@@ -182,7 +182,7 @@ int get_media_type(const char* filename)
       }
       return MEDIA_TYPE_CART;
    }
-   else if(strcmp(extension, ".sf7") == 0){
+   else if(strcmp(extension, "sf7") == 0){
       if (is_auto){
          is_sega = true;
          strcpy(msx_type, "SEGA - SF-7000");
@@ -196,7 +196,7 @@ int get_media_type(const char* filename)
       }
       return MEDIA_TYPE_CART;
    }
-   else if(strcmp(extension, ".omv") == 0){
+   else if(strcmp(extension, "omv") == 0){
       if (is_auto){
          is_sega = true;
          strcpy(msx_type, "Othello Multivision");
@@ -899,7 +899,7 @@ bool retro_load_game(const struct retro_game_info *info)
    if (info)
       extract_directory(base_dir, info->path, sizeof(base_dir));
 
-   check_variables();   // msx_type from configuration 
+   check_variables();   // msx_type from configuration
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir) && dir)
       strcpy(properties_dir, dir);

--- a/system/bluemsx/Databases/segadb.xml
+++ b/system/bluemsx/Databases/segadb.xml
@@ -1719,20 +1719,6 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 		</dump>
 	</software>
 	<software>
-		<title xml:lang="en">King&#39;s Valley</title>
-		<system>Sega</system>
-		<company>Konami</company>
-		<year>1985</year>
-		<country>JP</country>
-		<dump>
-			<original value="false" />
-			<rom>
-				<type>SG1000RamA</type>
-				<hash algo="sha1">922d23895c12707b2fc382ea5cb769c5cb9b5755</hash>
-			</rom>
-		</dump>
-	</software>
-	<software>
 		<title xml:lang="en">Konami&#39;s Ping-Pong</title>
 		<system>Sega</system>
 		<company>Konami</company>
@@ -3194,20 +3180,6 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 	</software>
 <!-- SF-7000 roms -->
 	<software>
-		<title xml:lang="en">Magical Kid Wiz</title>
-		<system>Sega</system>
-		<company>Sony</company>
-		<year>1986</year>
-		<country>JP</country>
-		<dump>
-			<original value="false" />
-			<rom>
-				<type>SC3000</type>
-				<hash algo="sha1">fd24b501046cf811b04386129be0362a1eabf6b3</hash>
-			</rom>
-		</dump>
-	</software>
-	<software>
 		<title xml:lang="en">Super Boy I</title>
 		<system>Sega</system>
 		<company>Zemina</company>
@@ -3278,6 +3250,7 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 			</systemrom>
 		</dump>
 	</software>
+<!-- Taiwan 8KB RAM expansion roms -->
 	<software>
 		<title xml:lang="en">Rally-X</title>
 		<system>Sega</system>
@@ -3287,7 +3260,7 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 		<dump>
 			<original value="false" />
 			<rom>
-				<type>sg1000ramA</type>
+				<type>sg1000ramB</type>
 				<hash algo="sha1">0c1957a5faae5254c69f3331e79d87499dd7cf48</hash>
 			</rom>
 		</dump>
@@ -3328,7 +3301,7 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 		</dump>
 	</software>
 	<software>
-		<title xml:lang="en">*Bomberman Special</title>
+		<title xml:lang="en">Bomberman Special</title>
 		<system>Sega</system>
 		<company>DahJee</company>
 		<year>1986</year>
@@ -3336,7 +3309,7 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 		<dump>
 			<original value="false" />
 			<rom>
-				<type>sg1000ramA</type>
+				<type>sg1000ramB</type>
 				<hash algo="sha1">d1d56bcd996df94458f5901dc537a5e30021256b</hash>
 			</rom>
 		</dump>
@@ -3349,7 +3322,7 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 		</dump>
 	</software>
 	<software>
-		<title xml:lang="en">Legend of Kage</title>
+		<title xml:lang="en">The Legend of Kage</title>
 		<system>Sega</system>
 		<company>DahJee</company>
 		<year>1986</year>
@@ -3378,7 +3351,7 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 		<dump>
 			<original value="false" />
 			<rom>
-				<type>sg1000ramA</type>
+				<type>sg1000ramB</type>
 				<hash algo="sha1">2755f74019dc94559fd0c2248e2ecb7f48879b90</hash>
 			</rom>
 		</dump>
@@ -3408,6 +3381,76 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 			<rom>
 				<type>sg1000ramA</type>
 				<hash algo="sha1">a8c30043c145e63f79a3265dde167529f0e08d49</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">Star Soldier</title>
+		<system>Sega</system>
+		<company>DahJee</company>
+		<year>19xx</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">c1984257809ec5bce80a65d22b9b32561e04922c</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">King's Valley</title>
+		<system>Sega</system>
+		<company>Jinzita</company>
+		<year>198x</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">922d23895c12707b2fc382ea5cb769c5cb9b5755</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">Pippols</title>
+		<system>Sega</system>
+		<company>Jumbo</company>
+		<year>198x</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">4a95b98e127fb0c6428d6debcfc92152069ac531</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">The Castle</title>
+		<system>Sega</system>
+		<company>DahJee</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramB</type>
+				<hash algo="sha1">5a81d5103487695cabd811aabd9e71f48b9e7996</hash>
+			</rom>
+		</dump>
+	</software>
+		<software>
+		<title xml:lang="en">Magical Kid Wiz</title>
+		<system>Sega</system>
+		<company>Sony</company>
+		<year>1986</year>
+		<country>JP</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramB</type>
+				<hash algo="sha1">fd24b501046cf811b04386129be0362a1eabf6b3</hash>
 			</rom>
 		</dump>
 	</software>

--- a/system/bluemsx/Databases/segadb.xml
+++ b/system/bluemsx/Databases/segadb.xml
@@ -3278,4 +3278,137 @@ f0f128b25e5557e660d936995e6bf25c8ebd17e5</hash>
 			</systemrom>
 		</dump>
 	</software>
+	<software>
+		<title xml:lang="en">Rally-X</title>
+		<system>Sega</system>
+		<company>DahJee</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">0c1957a5faae5254c69f3331e79d87499dd7cf48</hash>
+			</rom>
+		</dump>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">21770691191b62bafec9099bbe0f9942f5480f83</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">Tank Battalion</title>
+		<system>Sega</system>
+		<company>DahJee</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">0ca3b740b28266a2a606127ed8967c684b67cb44</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">Yie Ar Kung-Fu II</title>
+		<system>Sega</system>
+		<company>DahJee</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">44fb2dca3774f859f0ae0ad4d809a67f760cf9ae</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">*Bomberman Special</title>
+		<system>Sega</system>
+		<company>DahJee</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">d1d56bcd996df94458f5901dc537a5e30021256b</hash>
+			</rom>
+		</dump>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">455838571dd8287d491431e03269b0ccd292c8b8</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">Legend of Kage</title>
+		<system>Sega</system>
+		<company>DahJee</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">902dbb122bf0efc76604a876c3fae51c074bdc6a</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">Road Fighter</title>
+		<system>Sega</system>
+		<company>Jumbo</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">4f1a139974e3db27af5973bc9572ed68acd6ea68</hash>
+			</rom>
+		</dump>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">2755f74019dc94559fd0c2248e2ecb7f48879b90</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">Knightmare</title>
+		<system>Sega</system>
+		<company>Jumbo</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">babdb6b109b20e81c28cd892c2042723e9cbff49</hash>
+			</rom>
+		</dump>
+	</software>
+	<software>
+		<title xml:lang="en">TwinBee</title>
+		<system>Sega</system>
+		<company>Jumbo</company>
+		<year>1986</year>
+		<country>TW</country>
+		<dump>
+			<original value="false" />
+			<rom>
+				<type>sg1000ramA</type>
+				<hash algo="sha1">a8c30043c145e63f79a3265dde167529f0e08d49</hash>
+			</rom>
+		</dump>
+	</software>
 </softwaredb>


### PR DESCRIPTION
- Fix extension checking; files with two-character extensions like .sg are now working.
- The SG-1000 8KB RAM expansion mapper is now functioning and runs most games.
- Add SG-1000 games that use the expansion card.


## Fix extension checking

Previously, four characters were used to determine the file extension (.xyz):

`extension = workram + strlen(workram) - 4;`

The issue with this approach is that extensions with only two characters, like .sg and .sc, were not handled correctly. I modified the code to retrieve just three characters. Extensions with three characters are compared without the dot, while those with two characters are compared including the dot.

## SG-1000 8KB RAM expansion mapper 

This mapper was not working and was not applied to any game in [segadb.xml](https://github.com/libretro/blueMSX-libretro/blob/master/system/bluemsx/Databases/segadb.xml)

It has been corrected and tested with the following games:

- Rally-X crc32: AAAC12CF - working
- Rally-X crc32: 306D5F78 - not working
- Tank Battalion crc32: 5CBD1163 - not working
- Yie Ar Kung-Fu II crc32: FC87463C - working
- Bomberman Special crc32: 69FC1494 - working
- Bomberman Special crc32: CE5648C3 - not working
- The Legend of Kage crc32: 2E7166D5 - not working
- Road Fighter crc32: 29E047CC - working
- Road Fighter crc32: D2EDD329 - working
- Knightmare crc32: 281D2888 - working
- TwinBee crc32: C550B4F0 - working
- King's Valley crc32: 223397A1 - working
- Magical Kid Wiz crc32: FFC4EE3F - working
- Star Soldier crc32: E0816BB7 - not working
- Pippols  crc32: DF7CBFA5 - working
- The Castle (TW) crc32: 2E366CCF - working
