### PR TITLE
Improve disk interface struct initialization and M3U parsing

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -332,31 +332,35 @@ void attach_disk_swap_interface(void)
 
     if (version >= 1)
     {
-        struct retro_disk_control_ext_callback dskcb_ext = {
-            set_eject_state,
-            get_eject_state,
-            set_image_index,
-            get_image_index,
-            get_num_images,
-            replace_image_index,
-            add_image_index,
-            set_initial_image,
-            get_image_path,
-            get_image_label
-        };
+        struct retro_disk_control_ext_callback dskcb_ext;
+        memset(&dskcb_ext, 0, sizeof(dskcb_ext));
+
+        dskcb_ext.set_eject_state = set_eject_state;
+        dskcb_ext.get_eject_state = get_eject_state;
+        dskcb_ext.set_image_index = set_image_index;
+        dskcb_ext.get_image_index = get_image_index;
+        dskcb_ext.get_num_images = get_num_images;
+        dskcb_ext.replace_image_index = replace_image_index;
+        dskcb_ext.add_image_index = add_image_index;
+        dskcb_ext.set_initial_image = set_initial_image;
+        dskcb_ext.get_image_path = get_image_path;
+        dskcb_ext.get_image_label = get_image_label;
+
         environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE, &dskcb_ext);
     }
     else
     {
-        struct retro_disk_control_callback dskcb = {
-            set_eject_state,
-            get_eject_state,
-            set_image_index,
-            get_image_index,
-            get_num_images,
-            replace_image_index,
-            add_image_index
-        };
+        struct retro_disk_control_callback dskcb;
+        memset(&dskcb, 0, sizeof(dskcb));
+
+        dskcb.set_eject_state = set_eject_state;
+        dskcb.get_eject_state = get_eject_state;
+        dskcb.set_image_index = set_image_index;
+        dskcb.get_image_index = get_image_index;
+        dskcb.get_num_images = get_num_images;
+        dskcb.replace_image_index = replace_image_index;
+        dskcb.add_image_index = add_image_index;
+
         environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &dskcb);
     }
 }
@@ -366,6 +370,11 @@ static bool read_m3u(const char *file)
 {
    char line[PATH_MAX];
    char name[PATH_MAX];
+   char *carriage_return;
+   char *newline;
+   char *start;
+   char *end;
+
    FILE *f = fopen(file, "r");
 
    if (!f)
@@ -373,14 +382,9 @@ static bool read_m3u(const char *file)
 
    while (fgets(line, sizeof(line), f)
          && disk_images < 
-         sizeof(disk_paths) / sizeof(disk_paths[0])) 
+         sizeof(disk_paths) / sizeof(disk_paths[0]))
    {
-      char *carriage_return = NULL;
-      char *newline         = NULL;
-
-      if (line[0] == '#')
-         continue;
-
+      /* Remove CR/LF */
       carriage_return = strchr(line, '\r');
       if (carriage_return)
          *carriage_return = '\0';
@@ -389,12 +393,45 @@ static bool read_m3u(const char *file)
       if (newline)
          *newline = '\0';
 
-      if (line[0] != '\0')
-      {
-         snprintf(name, sizeof(name), "%s%c%s", base_dir, SLASH, line);
-         strcpy(disk_paths[disk_images], name);
-         disk_images++;
+      /* Skip comments */
+      if (line[0] == '#')
+         continue;
+
+      /* Trim leading whitespace */
+      start = line;
+      while (*start && isspace((unsigned char)*start))
+         start++;
+
+      /* Trim trailing whitespace */
+      end = start + strlen(start) - 1;
+      while (end >= start && isspace((unsigned char)*end)) {
+         *end = '\0';
+         end--;
       }
+
+      if (*start == '\0')
+         continue; /* Skip empty lines */
+
+      /* Handle absolute vs relative paths */
+#ifdef _WIN32
+      if ((start[0] && start[1] == ':') || start[0] == '\\' || start[0] == '/')
+#else
+      if (start[0] == '/')
+#endif
+      {
+         /* Absolute path */
+         strncpy(name, start, sizeof(name));
+         name[sizeof(name)-1] = '\0';
+      }
+      else
+      {
+         /* Relative path */
+         snprintf(name, sizeof(name), "%s%c%s", base_dir, SLASH, start);
+      }
+
+      strncpy(disk_paths[disk_images], name, PATH_MAX);
+      disk_paths[disk_images][PATH_MAX-1] = '\0';
+      disk_images++;
    }
 
    fclose(f);

--- a/libretro.c
+++ b/libretro.c
@@ -326,43 +326,43 @@ bool get_image_label(unsigned index, char *label, size_t len)
 
 void attach_disk_swap_interface(void)
 {
-    unsigned version = 0;
-    if (!environ_cb(RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION, &version))
-        version = 0;
+   unsigned version = 0;
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_DISK_CONTROL_INTERFACE_VERSION, &version))
+      version = 0;
 
-    if (version >= 1)
-    {
-        struct retro_disk_control_ext_callback dskcb_ext;
-        memset(&dskcb_ext, 0, sizeof(dskcb_ext));
+   if (version >= 1)
+   {
+      struct retro_disk_control_ext_callback dskcb_ext;
+      memset(&dskcb_ext, 0, sizeof(dskcb_ext));
 
-        dskcb_ext.set_eject_state = set_eject_state;
-        dskcb_ext.get_eject_state = get_eject_state;
-        dskcb_ext.set_image_index = set_image_index;
-        dskcb_ext.get_image_index = get_image_index;
-        dskcb_ext.get_num_images = get_num_images;
-        dskcb_ext.replace_image_index = replace_image_index;
-        dskcb_ext.add_image_index = add_image_index;
-        dskcb_ext.set_initial_image = set_initial_image;
-        dskcb_ext.get_image_path = get_image_path;
-        dskcb_ext.get_image_label = get_image_label;
+      dskcb_ext.set_eject_state = set_eject_state;
+      dskcb_ext.get_eject_state = get_eject_state;
+      dskcb_ext.set_image_index = set_image_index;
+      dskcb_ext.get_image_index = get_image_index;
+      dskcb_ext.get_num_images = get_num_images;
+      dskcb_ext.replace_image_index = replace_image_index;
+      dskcb_ext.add_image_index = add_image_index;
+      dskcb_ext.set_initial_image = set_initial_image;
+      dskcb_ext.get_image_path = get_image_path;
+      dskcb_ext.get_image_label = get_image_label;
 
-        environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE, &dskcb_ext);
-    }
-    else
-    {
-        struct retro_disk_control_callback dskcb;
-        memset(&dskcb, 0, sizeof(dskcb));
+      environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE, &dskcb_ext);
+   }
+   else
+   {
+      struct retro_disk_control_callback dskcb;
+      memset(&dskcb, 0, sizeof(dskcb));
 
-        dskcb.set_eject_state = set_eject_state;
-        dskcb.get_eject_state = get_eject_state;
-        dskcb.set_image_index = set_image_index;
-        dskcb.get_image_index = get_image_index;
-        dskcb.get_num_images = get_num_images;
-        dskcb.replace_image_index = replace_image_index;
-        dskcb.add_image_index = add_image_index;
+      dskcb.set_eject_state = set_eject_state;
+      dskcb.get_eject_state = get_eject_state;
+      dskcb.set_image_index = set_image_index;
+      dskcb.get_image_index = get_image_index;
+      dskcb.get_num_images = get_num_images;
+      dskcb.replace_image_index = replace_image_index;
+      dskcb.add_image_index = add_image_index;
 
-        environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &dskcb);
-    }
+      environ_cb(RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE, &dskcb);
+   }
 }
 /* end .dsk swap support */
 
@@ -374,15 +374,14 @@ static bool read_m3u(const char *file)
    char *newline;
    char *start;
    char *end;
+   FILE *f;
 
-   FILE *f = fopen(file, "r");
-
+   f = fopen(file, "r");
    if (!f)
       return false;
 
-   while (fgets(line, sizeof(line), f)
-         && disk_images < 
-         sizeof(disk_paths) / sizeof(disk_paths[0]))
+   while (fgets(line, sizeof(line), f) &&
+          disk_images < (sizeof(disk_paths) / sizeof(disk_paths[0])))
    {
       /* Remove CR/LF */
       carriage_return = strchr(line, '\r');
@@ -404,7 +403,8 @@ static bool read_m3u(const char *file)
 
       /* Trim trailing whitespace */
       end = start + strlen(start) - 1;
-      while (end >= start && isspace((unsigned char)*end)) {
+      while (end >= start && isspace((unsigned char)*end))
+      {
          *end = '\0';
          end--;
       }
@@ -414,14 +414,15 @@ static bool read_m3u(const char *file)
 
       /* Handle absolute vs relative paths */
 #ifdef _WIN32
-      if ((start[0] && start[1] == ':') || start[0] == '\\' || start[0] == '/')
+      if ((start[0] && start[1] == ':') ||
+          start[0] == '\\' || start[0] == '/')
 #else
       if (start[0] == '/')
 #endif
       {
          /* Absolute path */
          strncpy(name, start, sizeof(name));
-         name[sizeof(name)-1] = '\0';
+         name[sizeof(name) - 1] = '\0';
       }
       else
       {
@@ -430,7 +431,7 @@ static bool read_m3u(const char *file)
       }
 
       strncpy(disk_paths[disk_images], name, PATH_MAX);
-      disk_paths[disk_images][PATH_MAX-1] = '\0';
+      disk_paths[disk_images][PATH_MAX - 1] = '\0';
       disk_images++;
    }
 

--- a/libretro.c
+++ b/libretro.c
@@ -307,22 +307,41 @@ bool get_image_label(unsigned index, char *label, size_t len)
 {
     char *dot;
     const char *filename;
+    const char *slash;
+#ifdef _WIN32
+    const char *alt_slash;
+#endif
     size_t copy_len;
-    if (index >= disk_images) return false;
+
+    if (index >= disk_images) 
+        return false;
+
+    slash = strrchr(disk_paths[index], SLASH);
+
+#ifdef _WIN32
+    /* Also check for the other slash type on Windows */
+    alt_slash = strrchr(disk_paths[index], (SLASH == '\\') ? '/' : '\\');
     
-    filename = strrchr(disk_paths[index], '/');
-    filename = filename ? filename + 1 : disk_paths[index];
-    
+    if (!slash || (alt_slash && alt_slash > slash))
+        slash = alt_slash;
+#endif
+
+    filename = slash ? slash + 1 : disk_paths[index];
+
     /* Remove extension */
-    dot      = strrchr(filename, '.');
+    dot = strrchr(filename, '.');
     copy_len = dot ? (size_t)(dot - filename) : strlen(filename);
-    
-    if (copy_len >= len) copy_len = len - 1;
-    
+
+    if (copy_len >= len) 
+      copy_len = len - 1;
+
     strncpy(label, filename, copy_len);
     label[copy_len] = '\0';
+
     return true;
 }
+
+
 
 void attach_disk_swap_interface(void)
 {


### PR DESCRIPTION
Replaces C99 struct initializers with explicit zeroing and assignment for disk control callbacks to improve compatibility. Enhances M3U file parsing by trimming whitespace, skipping empty lines, and handling both absolute and relative paths for disk images.

Fixes issue: #186 