### PR TITLE
Implement Disk Save Overlay system

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -194,6 +194,7 @@ SOURCES_C  += $(CORE_DIR)/Src/Z80/R800SaveState.c
 SOURCES_C  += $(CORE_DIR)/Src/Z80/R800Debug.c
 
 SOURCES_C  += $(CORE_DIR)/Src/IoDevice/Casette.c
+SOURCES_C  += $(CORE_DIR)/Src/IoDevice/DiskOverlay.c
 SOURCES_C  += $(CORE_DIR)/Src/IoDevice/DirAsDisk.c
 SOURCES_C  += $(CORE_DIR)/Src/IoDevice/Disk.c
 SOURCES_C  += $(CORE_DIR)/Src/IoDevice/FdcAudio.c

--- a/Src/Emulator/Actions.c
+++ b/Src/Emulator/Actions.c
@@ -26,6 +26,7 @@
 ******************************************************************************
 */
 #include "Actions.h"
+#include "DiskOverlay.h"
 #include "MsxTypes.h"
 #include "Switches.h"
 #include "AudioMixer.h"
@@ -124,13 +125,16 @@ void actionDiskInsertDir(int diskNo)
     archUpdateMenu(0);
 }
 
-void actionDiskRemove(int i) {
+void actionDiskRemove(int i) 
+{
     state.properties->media.disks[i].fileName[0] = 0;
     state.properties->media.disks[i].fileNameInZip[0] = 0;
     updateExtendedDiskName(i, state.properties->media.disks[i].fileName, state.properties->media.disks[i].fileNameInZip);
-    if (emulatorGetState() != EMU_STOPPED) {
+    if (emulatorGetState() != EMU_STOPPED) 
+    {
         emulatorSuspend();
         boardChangeDiskette(i, NULL, NULL);
+        unmountDiskOverlay(i);
         emulatorResume();
     }
     archUpdateMenu(0);

--- a/Src/IoDevice/DiskOverlay.c
+++ b/Src/IoDevice/DiskOverlay.c
@@ -1,0 +1,189 @@
+/*
+ * DiskOverlay.c - Disk overlay system for persistent disk writes
+ *
+ * This module provides an in-memory overlay for disk sectors, allowing
+ * persistent writes to be stored in a separate file without modifying the
+ * original disk image.
+ */
+
+#include "DiskOverlay.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+DiskOverlay_t* diskOverlayCreate(size_t sectorSize)
+{
+   DiskOverlay_t* ov;
+   ov = (DiskOverlay_t*)calloc(1, sizeof(DiskOverlay_t));
+   if (ov)
+      ov->sectorSize = sectorSize;
+   return ov;
+}
+
+void diskOverlayFree(DiskOverlay_t* overlay)
+{
+   DiskOverlayEntry_t* e;
+   DiskOverlayEntry_t* next;
+
+   if (!overlay)
+      return;
+
+   e = overlay->head;
+
+   while (e)
+   {
+      next = e->next;
+      free(e->data);
+      free(e);
+      e = next;
+   }
+   free(overlay);
+}
+
+void diskOverlayWrite(DiskOverlay_t* overlay, int sector, const uint8_t* data)
+{
+   DiskOverlayEntry_t* prev;
+   DiskOverlayEntry_t* e;
+   if (!overlay)
+      return;
+
+   prev = NULL;
+   e = overlay->head;
+   while (e)
+   {
+      if (e->sector == sector)
+      {
+         memcpy(e->data, data, overlay->sectorSize);
+         /* Optionally move to head for LRU, but not required */
+         return;
+      }
+      prev = e;
+      e = e->next;
+   }
+
+   e = (DiskOverlayEntry_t*)malloc(sizeof(DiskOverlayEntry_t));
+   if (!e)
+      return;
+   e->sector = sector;
+   e->data = (uint8_t*)malloc(overlay->sectorSize);
+   if (!e->data)
+   {
+      free(e);
+      return;
+   }
+   memcpy(e->data, data, overlay->sectorSize);
+   e->next = overlay->head;
+   overlay->head = e;
+}
+
+int diskOverlayRead(DiskOverlay_t* overlay, int sector, uint8_t* out)
+{
+   DiskOverlayEntry_t* e;
+   if (!overlay)
+      return 0;
+
+   e = overlay->head;
+   while (e)
+   {
+      if (e->sector == sector)
+      {
+         memcpy(out, e->data, overlay->sectorSize);
+         return 1;
+      }
+      e = e->next;
+   }
+
+   return 0;
+}
+
+int diskOverlayIsEmpty(DiskOverlay_t* overlay)
+{
+   return (overlay == NULL || overlay->head == NULL);
+}
+
+int diskOverlaySerialize(DiskOverlay_t* overlay, const char* path)
+{
+   FILE* f;
+   DiskOverlayEntry_t* e;
+
+   if (!overlay || !path)
+      return 0;
+
+   f = fopen(path, "wb");
+   if (!f)
+      return 0;
+
+   e = overlay->head;
+   while (e)
+   {
+      fwrite(&e->sector, sizeof(int), 1, f);
+      fwrite(e->data, 1, overlay->sectorSize, f);
+      e = e->next;
+   }
+
+   fclose(f);
+   return 1;
+}
+
+DiskOverlay_t* diskOverlayDeserialize(const char* path, size_t sectorSize)
+{
+   FILE* f;
+   DiskOverlay_t* ov;
+   int sector;
+   uint8_t* buf;
+   size_t n;
+   DiskOverlayEntry_t* prev;
+   DiskOverlayEntry_t* e;
+
+   if (!path)
+      return NULL;
+
+   f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+
+   ov = diskOverlayCreate(sectorSize);
+   if (!ov)
+   {
+      fclose(f);
+      return NULL;
+   }
+
+   buf = (uint8_t*)malloc(sectorSize);
+   if (!buf)
+   {
+      fclose(f);
+      diskOverlayFree(ov);
+      return NULL;
+   }
+
+   while (fread(&sector, sizeof(int), 1, f) == 1)
+   {
+      n = fread(buf, 1, sectorSize, f);
+      if (n != sectorSize)
+         break;
+      /* Remove any previous entry for this sector before writing */
+      prev = NULL;
+      e = ov->head;
+      while (e)
+      {
+         if (e->sector == sector)
+         {
+            if (prev)
+               prev->next = e->next;
+            else
+               ov->head = e->next;
+            free(e->data);
+            free(e);
+            break;
+         }
+         prev = e;
+         e = e->next;
+      }
+      diskOverlayWrite(ov, sector, buf);
+   }
+
+   free(buf);
+   fclose(f);
+   return ov;
+}

--- a/Src/IoDevice/DiskOverlay.h
+++ b/Src/IoDevice/DiskOverlay.h
@@ -1,0 +1,34 @@
+#ifndef DISKOVERLAY_H
+#define DISKOVERLAY_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * DiskOverlayEntry_t - Linked list entry for a disk overlay sector
+ */
+typedef struct DiskOverlayEntry_t
+{
+   int sector;
+   uint8_t* data;
+   struct DiskOverlayEntry_t* next;
+} DiskOverlayEntry_t;
+
+/**
+ * DiskOverlay_t - Overlay structure for disk sectors
+ */
+typedef struct DiskOverlay_t
+{
+   DiskOverlayEntry_t* head;
+   size_t sectorSize;
+} DiskOverlay_t;
+
+DiskOverlay_t* diskOverlayCreate(size_t sectorSize);
+void diskOverlayFree(DiskOverlay_t* overlay);
+void diskOverlayWrite(DiskOverlay_t* overlay, int sector, const uint8_t* data);
+int diskOverlayRead(DiskOverlay_t* overlay, int sector, uint8_t* out);
+int diskOverlaySerialize(DiskOverlay_t* overlay, const char* path);
+DiskOverlay_t* diskOverlayDeserialize(const char* path, size_t sectorSize);
+int diskOverlayIsEmpty(DiskOverlay_t* overlay);
+
+#endif /* DISKOVERLAY_H */

--- a/libretro.c
+++ b/libretro.c
@@ -75,6 +75,7 @@ static int hard_reset_f12_pressed = 0;
 static int input_analog_deadzone = (int)(0.25f * (float)0x8000);
 
 char overlayDir[512] = {0};
+int overlayTimer = -1;
 
 static void reevaluate_variables_io_sound(bool setToMixer);
 
@@ -1517,6 +1518,15 @@ void retro_run(void)
    else
       video_cb(image_buffer, image_buffer_current_width, image_buffer_height, image_buffer_current_width * sizeof(uint16_t));
 
+   if (overlayTimer >= 0)
+   {
+      overlayTimer++;
+      if (overlayTimer >= 60)
+      {
+         writeDiskOverlay(0);
+         overlayTimer = -1;
+      }
+   }
 }
 
 /* framebuffer */

--- a/libretro.c
+++ b/libretro.c
@@ -31,6 +31,7 @@
 #include "InputEvent.h"
 #include "R800.h"
 #include "Src/Utils/SaveState.h"
+#include "DiskOverlay.h"
 
 #include "ziphelper.c"
 
@@ -72,6 +73,8 @@ int hard_reset_f12 = 0;
 static int sega_nmi_pressed = 0;
 static int hard_reset_f12_pressed = 0;
 static int input_analog_deadzone = (int)(0.25f * (float)0x8000);
+
+char overlayDir[512] = {0};
 
 static void reevaluate_variables_io_sound(bool setToMixer);
 
@@ -247,6 +250,7 @@ bool set_image_index(unsigned index)
    if(disk_index == disk_images)
    {
       //retroarch is trying to set "no disk in tray"
+      unmountDiskOverlay(0);
       return true;
    }
    
@@ -1036,7 +1040,11 @@ bool retro_load_game(const struct retro_game_info *info)
    machineSetDirectory(machines_dir);
 
    if(environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &save_dir) && save_dir)
+   {
       boardSetDirectory(save_dir);
+      strncpy(overlayDir, save_dir, sizeof(overlayDir) - 1);
+      overlayDir[sizeof(overlayDir) - 1] = 0;
+   }
 
 #if 0
    boardSetDirectory(buffer);
@@ -1581,6 +1589,8 @@ bool retro_load_game_special(unsigned a, const struct retro_game_info *b, size_t
 
 void retro_unload_game(void)
 {
+   unmountDiskOverlay(0);
+
    if (image_buffer)
       free(image_buffer);
    


### PR DESCRIPTION
Add disk overlay support for persistent disk writes

Introduces a disk save overlay system to capture and persist disk write operations in a separate overlay file stored in the libretro save directory, preventing changes to the original disk image. Integrates overlay mounting and unmounting logic into disk insertion/removal and emulator lifecycle, and updates disk read/write functions to use overlays when present. Adds new DiskOverlay module with serialization, deserialization, and in-memory sector management.