### PR TITLE
Fix Nintendo Switch crash with MSX systems

### DIFF
--- a/Src/Board/Machine.c
+++ b/Src/Board/Machine.c
@@ -231,6 +231,23 @@ char *strcasestr(const char *h, const char *n)
 }
 #endif
 
+#if defined(__SWITCH__)
+const char *strcasestr(const char *haystack, const char *needle) {
+    if (!*needle) return haystack;
+
+    for (; *haystack; haystack++) {
+        const char *h = haystack;
+        const char *n = needle;
+        while (*h && *n && tolower((unsigned char)*h) == tolower((unsigned char)*n)) {
+            h++;
+            n++;
+        }
+        if (!*n) return haystack; // full match
+    }
+    return NULL;
+}
+#endif
+
 static int readMachine(Machine* machine, const char* machineName, const char* file)
 {
     static char buffer[10000];


### PR DESCRIPTION
libnx library doesn't have a strcasestr implementation, but for some reason it still links at the end (not sure why, it's first time I use libnx and compile a libretro core).
What happens is that when readMachine function check the location of the bios files to load, it uses strcasestr function to check if location starts with Machines/ and if it's the case, it adds the bios folder as a prefix (typically /retroarch/cores/system/ on the Nintendo Switch). As the strcasestr function doesn't work as expected, the bios folder is never added and bios are never loaded, which is causing a blueMSX crash.
This commit adds a proper strcasestr implementation for the libnx target.
Fix for #112 #116 #139 #149 #162