### PR TITLE
Fix buffer overflow in MEDIA_TYPE_DISK_BUNDLE when reading .m3u files

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -1207,8 +1207,8 @@ bool retro_load_game(const struct retro_game_info *info)
             }
             for (i = 0; i < disk_images; i++)
             {
-               strncpy(properties->media.disks[i].fileName, disk_paths[i], PATH_MAX);
-               properties->media.disks[i].fileName[PATH_MAX-1] = '\0';
+               strncpy(properties->media.disks[i].fileName, disk_paths[i], sizeof(properties->media.disks[i].fileName) - 1);
+               properties->media.disks[i].fileName[sizeof(properties->media.disks[i].fileName) - 1] = '\0';
             }
             disk_inserted = true;
             attach_disk_swap_interface();


### PR DESCRIPTION
This PR fixes a buffer overflow issue that occurs when loading disk bundles (MEDIA_TYPE_DISK_BUNDLE) via .m3u files. Previously, filenames were copied into fixed-size buffers without proper bounds checking, which could lead to crashes when the disk path exceeded the buffer size.

<img width="903" height="899" alt="image" src="https://github.com/user-attachments/assets/bff77149-d9c2-4d21-a2c6-f74ff6fa4666" />
