### PR TITLE
Fix PAL audio crackling: exact VDP timing and standard libretro audio delivery

### DIFF
--- a/Src/Board/Board.c
+++ b/Src/Board/Board.c
@@ -763,7 +763,6 @@ int boardRun(Machine* machine,
         }
 
 #ifdef __LIBRETRO__
-        boardTimerAdd(mixerTimer, boardSystemTime() + boardFrequency() / 50);
         return success;
 #else
         boardTimerAdd(syncTimer, boardSystemTime() + 1);

--- a/Src/Libretro/Sound.c
+++ b/Src/Libretro/Sound.c
@@ -28,21 +28,9 @@
 ******************************************************************************
 */
 #include "ArchSound.h"
-#include "libretro.h"
-
-static retro_audio_sample_batch_t audio_batch_cb = NULL;
-void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { audio_batch_cb = cb; }
-
-static Int32 soundWrite(void* dummy, Int16 *buffer, UInt32 count)
-{
-   if (audio_batch_cb)
-      return (Int32)audio_batch_cb(buffer, count / 2);
-   return 0;
-}
 
 void archSoundCreate(Mixer* mixer, UInt32 sampleRate, UInt32 bufferSize, Int16 channels) {
     mixerSetStereo(mixer, channels == 2);
-    mixerSetWriteCallback(mixer, soundWrite, NULL, 512);
 }
 
 void archSoundDestroy(void) {}

--- a/Src/SoundChips/AudioMixer.c
+++ b/Src/SoundChips/AudioMixer.c
@@ -113,9 +113,6 @@ typedef struct
 
 struct Mixer
 { 
-    MixerWriteCallback writeCallback;
-    void*  writeRef;
-    Int32  fragmentSize;
     UInt32 refTime;
     UInt32 refFrag;
     UInt32 index;
@@ -322,7 +319,6 @@ Mixer* mixerCreate(void)
 {
     Mixer* mixer        = (Mixer*)calloc(1, sizeof(Mixer));
 
-    mixer->fragmentSize = 512;
     mixer->enable       = 1;
     mixer->rate         = AUDIO_SAMPLERATE;
 
@@ -351,16 +347,6 @@ void mixerSetSampleRate(Mixer* mixer, UInt32 rate)
         if (mixer->channels[i].rateCallback != NULL)
             mixer->channels[i].rateCallback(mixer->channels[i].ref, rate);
     }
-}
-
-void mixerSetWriteCallback(Mixer* mixer, MixerWriteCallback callback, void* ref, int fragmentSize)
-{
-    mixer->fragmentSize = fragmentSize;
-    mixer->writeCallback = callback;
-    mixer->writeRef = ref;
-
-    if (mixer->fragmentSize <= 0)
-        mixer->fragmentSize = 512;
 }
 
 Int32 mixerRegisterChannel(Mixer* mixer, Int32 audioType, Int32 stereo, MixerUpdateCallback callback, MixerSetSampleRateCallback rateCallback, void* ref)
@@ -450,12 +436,6 @@ void mixerSync(Mixer* mixer)
             else
                 buffer[mixer->index++] = 0;
 
-            if (mixer->index == mixer->fragmentSize)
-	    {
-                if (mixer->writeCallback != NULL)
-                    mixer->writeCallback(mixer->writeRef, buffer, mixer->fragmentSize);
-                mixer->index = 0;
-            }
         }
         return;
     }
@@ -516,13 +496,6 @@ void mixerSync(Mixer* mixer)
             buffer[mixer->index++] = (Int16)left;
             buffer[mixer->index++] = (Int16)right;
 
-            if (mixer->index == mixer->fragmentSize)
-	    {
-                if (mixer->writeCallback != NULL)
-                    mixer->writeCallback(mixer->writeRef, buffer, mixer->fragmentSize);
-                mixer->index = 0;
-            }
-
             mixer->volIndex++;
         }
     }
@@ -561,13 +534,6 @@ void mixerSync(Mixer* mixer)
             if (left  < -32767) left  = -32767;
 
             buffer[mixer->index++] = (Int16)left;
-            
-            if (mixer->index == mixer->fragmentSize)
-	    {
-                if (mixer->writeCallback != NULL)
-                    mixer->writeCallback(mixer->writeRef, buffer, mixer->fragmentSize);
-                mixer->index = 0;
-            }
 
             mixer->volIndex++;
         }

--- a/Src/SoundChips/AudioMixer.h
+++ b/Src/SoundChips/AudioMixer.h
@@ -61,8 +61,6 @@ typedef enum {
 
 typedef Int32* (*MixerUpdateCallback)(void*, UInt32);
 typedef void (*MixerSetSampleRateCallback)(void*, UInt32);
-typedef Int32 (*MixerWriteCallback)(void*, Int16*, UInt32);
-
 /* Constructor and destructor */
 Mixer* mixerCreate();
 void mixerDestroy(Mixer* mixer);
@@ -79,9 +77,6 @@ void mixerSetChannelTypeVolume(Mixer* mixer, Int32 channelType, Int32 volume);
 void mixerSetChannelTypePan(Mixer* mixer, Int32 channelType, Int32 pan);
 void mixerEnableChannelType(Mixer* mixer, Int32 channelType, Int32 enable);
 Int32 mixerIsChannelTypeActive(Mixer* mixer, Int32 channelType, Int32 reset);
-
-/* Write callback registration for audio drivers */
-void mixerSetWriteCallback(Mixer* mixer, MixerWriteCallback callback, void*, int);
 
 /* Internal interface methods */
 void mixerReset(Mixer* mixer);

--- a/Src/VideoChips/VDP.c
+++ b/Src/VideoChips/VDP.c
@@ -130,7 +130,7 @@ void vdpUnregisterDaConverter(int vdpDaHandle)
 
 // VDP emulation
 
-#define HPERIOD      1368
+#define HPERIOD      VDP_HTICKS
 
 #define INT_IE0     0x01
 #define INT_IE1     0x02

--- a/Src/VideoChips/VDP.h
+++ b/Src/VideoChips/VDP.h
@@ -55,6 +55,10 @@ void vdpForceSync();
 #define VDP_VIDEODA_WIDTH  544
 #define VDP_VIDEODA_HEIGHT 240
 
+#define VDP_HTICKS       1368
+#define VDP_LINES_NTSC   262
+#define VDP_LINES_PAL    313
+
 typedef struct {
     void (*daStart)(void*, int);
     void (*daEnd)(void*);

--- a/libretro.c
+++ b/libretro.c
@@ -40,6 +40,7 @@
 
 retro_log_printf_t log_cb;
 static retro_video_refresh_t video_cb;
+static retro_audio_sample_batch_t audio_batch_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
 static retro_environment_t environ_cb;
@@ -85,6 +86,7 @@ static void reevaluate_variables_io_sound(bool setToMixer);
 static void check_variables(bool can_change_machine_type);
 
 void retro_set_video_refresh(retro_video_refresh_t cb) { video_cb = cb; }
+void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { audio_batch_cb = cb; }
 void retro_set_input_poll(retro_input_poll_t cb) { input_poll_cb = cb; }
 void retro_set_input_state(retro_input_state_t cb) { input_state_cb = cb; }
 
@@ -668,8 +670,12 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.max_width = FB_MAX_LINE_WIDTH ;
    info->geometry.max_height = FB_MAX_LINES ;
    info->geometry.aspect_ratio = 0;
-   info->timing.fps = (retro_get_region() == RETRO_REGION_NTSC) ? 60.0 : 50.0;
-   info->timing.sample_rate = 44100.0;
+   /* Exact VDP timing: boardFrequency() Hz master clock, VDP_HTICKS ticks/line
+      NTSC: VDP_LINES_NTSC lines/frame (~59.9227 Hz), PAL: VDP_LINES_PAL lines/frame (~50.1566 Hz) */
+   info->timing.fps = (retro_get_region() == RETRO_REGION_NTSC)
+      ? ((double)boardFrequency() / (VDP_HTICKS * VDP_LINES_NTSC))
+      : ((double)boardFrequency() / (VDP_HTICKS * VDP_LINES_PAL));
+      info->timing.sample_rate = 44100.0;
 }
 
 void init_input_descriptors(unsigned device){
@@ -1618,7 +1624,14 @@ void retro_run(void)
    }
 
    ((R800*)boardInfo.cpuRef)->terminate = 0;
-   boardInfo.run(boardInfo.cpuRef);   
+   boardInfo.run(boardInfo.cpuRef);
+   mixerSync(boardGetMixer());
+   {
+      UInt32 samples;
+      Int16* buf = mixerGetBuffer(boardGetMixer(), &samples);
+      if (audio_batch_cb && samples > 0)
+         audio_batch_cb(buf, samples / 2);
+   }
    RETRO_PERFORMANCE_STOP(core_retro_run);
 
    if (!use_overscan)


### PR DESCRIPTION
Fixes #124

PAL audio was crackling due to two issues:

### 1. Wrong fps declaration

`timing.fps` was hardcoded to `50.0` instead of the exact VDP frame rate (`boardFrequency() / (VDP_HTICKS × VDP_LINES_PAL) ~ 50.1566 Hz`).
RetroArch's DRC targeted 882 samples/frame while the core produced 879.21 on average — a deficit of ~2.79 samples/frame. The audio buffer drained to zero approximately every 316 frames (~6 seconds), causing a periodic underrun glitch.

### 2. Misaligned audio flush

The periodic `mixerTimer` fired every `boardFrequency()/50 = 429,545` cycles, which does not align with the VDP frame boundary (428,184 cycles), producing slightly wrong sample counts per frame.

---

### Changes

- Add `VDP_HTICKS`, `VDP_LINES_NTSC`, `VDP_LINES_PAL` constants to `VDP.h`; use `VDP_HTICKS` for `HPERIOD` in `VDP.c`
- Compute exact fps from VDP constants in `libretro.c` for both PAL and NTSC
- Remove push callback infrastructure from `AudioMixer` (`writeCallback`, `writeRef`, `mixerSetWriteCallback`, autoflush logic in `mixerSync`)
- Strip `Sound.c` to just `mixerSetStereo`; move `audio_batch_cb` and `retro_set_audio_sample_batch` to `libretro.c`
- Deliver audio the standard libretro way: call `mixerSync()` + `audio_batch_cb()` once per frame at the end of `retro_run()`, aligned with VInt
- Remove `boardTimerAdd(mixerTimer, ...)` from the `__LIBRETRO__` build path in `Board.c`