### PR TITLE
Add Emscripten build support and C-BIOS machine fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 *.so
 .vscode/pro-deployer.json
+bluemsx_libretro_emscripten.bc

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -425,6 +425,11 @@ else ifneq (,$(findstring armv,$(platform)))
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	STATIC_LINKING = 1
+	# Clang 16+ promotes incompatible-pointer-types to errors by default.
+	# blueMSX's C89 codebase and its bundled zlib trigger this with
+	# unsigned long vs unsigned int pointer assignments.
+	CFLAGS += -Wno-incompatible-function-pointer-types -Wno-incompatible-pointer-types
+	CXXFLAGS += -Wno-incompatible-function-pointer-types
 
 # Genode
 else ifeq ($(platform), genode)

--- a/libretro.c
+++ b/libretro.c
@@ -1407,7 +1407,26 @@ bool retro_load_game(const struct retro_game_info *info)
       insertCartridge(properties, first_free_slot, msx_additional_cart, NULL, mediaDbStringToType(msx_additional_cart), -1);
 
    {
+      /*
+       * C-BIOS fallback: machines auto-detected by file extension (e.g. "MSX2+" for .rom
+       * files) reference proprietary BIOS ROMs that users may not have. If the requested
+       * machine fails to load, cascade through C-BIOS variants which use freely
+       * redistributable ROMs included in the core's system files.
+       */
       Machine* machine = machineCreate(properties->emulation.machineName);
+      if (!machine) {
+         if (log_cb) log_cb(RETRO_LOG_WARN, "Machine '%s' not found, trying C-BIOS fallback\n", properties->emulation.machineName);
+         strncpy(properties->emulation.machineName, "MSX2+ - C-BIOS", sizeof(properties->emulation.machineName) - 1);
+         machine = machineCreate(properties->emulation.machineName);
+      }
+      if (!machine) {
+         strncpy(properties->emulation.machineName, "MSX2 - C-BIOS", sizeof(properties->emulation.machineName) - 1);
+         machine = machineCreate(properties->emulation.machineName);
+      }
+      if (!machine) {
+         strncpy(properties->emulation.machineName, "MSX - C-BIOS", sizeof(properties->emulation.machineName) - 1);
+         machine = machineCreate(properties->emulation.machineName);
+      }
       if (!machine)
          return false;
       boardSetMachine(machine);


### PR DESCRIPTION
- Suppress incompatible-pointer-types warnings that Clang 16+ promotes to errors when compiling blueMSX's C89 codebase and its bundled zlib against the Emscripten toolchain.

- When a machine created from auto-detected type (e.g. MSX2+ for .rom files) fails to load because it references proprietary BIOS ROMs the user may not have, fall back through the freely redistributable C-BIOS variants: MSX2+ -> MSX2 -> MSX.